### PR TITLE
Fix «local variable 'inboxuids' referenced before assignment» when calling --teachonly

### DIFF
--- a/isbg.py
+++ b/isbg.py
@@ -553,6 +553,7 @@ h_tolearn, h_learnt = sa_learn_ham(opts, learnhambox, exitcodeimap,
 
 def filter_uids(opts, spaminbox, exitcodeimap, imapinbox, maxsize,
                 pastuidsfile, partialrun):
+    inboxuids = []
     if opts["--teachonly"] is False:
         # check spaminbox exists by examining it
         res = imap.select(spaminbox, 1)

--- a/isbg.py
+++ b/isbg.py
@@ -590,7 +590,7 @@ try:
         # Take only X elements if partialrun is enabled
         if partialrun is not None:
             totaluids = len(uids)
-            uids = uids[:int(partialrun)]
+            uids = uids[int(partialrun)*-1:]
             global pendinguids
             pendinguids = totaluids - len(uids)
 


### PR DESCRIPTION
If isbg is called with --teachonly option it complains with the following error:
Traceback (most recent call last):
  File "isbg/isbg.py", line 598, in <module>
    partialrun)
  File "isbg/isbg.py", line 583, in filter_uids
    uids = [u for u in inboxuids if u not in pastuids]
UnboundLocalError: local variable 'inboxuids' referenced before assignment

Defining inboxuids as an empty list in case we are in --teachonly solves the issue
